### PR TITLE
Fixes bug when pausing in fullscreen (iOS)

### DIFF
--- a/RCTVideo.m
+++ b/RCTVideo.m
@@ -363,7 +363,7 @@ static NSString *const playbackRate = @"rate";
       _playerBufferEmpty = YES;
     } else if ([keyPath isEqualToString:playbackLikelyToKeepUpKeyPath]) {
       // Continue playing (or not if paused) after being paused due to hitting an unbuffered zone.
-      if ((!_controls || _playerBufferEmpty) && _playerItem.playbackLikelyToKeepUp) {
+      if ((!(_controls || _fullscreenPlayerPresented) || _playerBufferEmpty) && _playerItem.playbackLikelyToKeepUp) {
         [self setPaused:_paused];
       }
       _playerBufferEmpty = NO;


### PR DESCRIPTION
Similar to #153, attempts to pause in fullscreen mode will be negated by the `playbackLikelyToKeepUp` event.

This PR adds a check for `_fullscreenPlayerPresented`, in additional to `_controls` before calling `setPaused` for `playbackLikelytoKeepUp`.

This update is likely preferrable to #258, as it doesn't lose the empty buffer check.
